### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,30 +7,43 @@
   <name>ArchiveFS</name>
   <version>0.1-SNAPSHOT</version>
 
+  <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <tika.version>2.4.1</tika.version>
+  </properties>
+
   <dependencies>
 
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.7</version>
+      <version>${tika.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
-      <version>1.7</version>
+      <artifactId>tika-parser-pkg-module</artifactId>
+      <version>${tika.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.9</version>
+      <version>1.21</version>
     </dependency>
 
     <dependency>
       <groupId>com.github.junrar</groupId>
       <artifactId>junrar</artifactId>
-      <version>0.7</version>
+      <version>7.5.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
     </dependency>
 
     <dependency>
@@ -47,11 +60,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
+        <version>3.10.1</version>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/io/mkr/archivefs/archive/rar/RarArchiveItem.java
+++ b/src/main/java/io/mkr/archivefs/archive/rar/RarArchiveItem.java
@@ -13,7 +13,7 @@ public class RarArchiveItem extends DelegatingArchiveItem<FileHeader> {
 
   @Override
   public String getPath() {
-    return getDelegate().getFileNameW().equals("") ? getDelegate().getFileNameString() : getDelegate().getFileNameW();
+    return getDelegate().getFileName();
   }
 
   @Override

--- a/src/main/java/io/mkr/archivefs/archive/rar/RarFileArchive.java
+++ b/src/main/java/io/mkr/archivefs/archive/rar/RarFileArchive.java
@@ -1,6 +1,5 @@
 package io.mkr.archivefs.archive.rar;
 
-import com.github.junrar.exception.RarException;
 import com.github.junrar.rarfile.FileHeader;
 import io.mkr.archivefs.archive.Archive;
 import io.mkr.archivefs.archive.ArchiveItem;
@@ -41,11 +40,7 @@ public class RarFileArchive implements Archive, Closeable {
     if (fh.isSplitAfter() || fh.isSplitBefore()) {
       throw new IllegalArgumentException("Multi volume archives not supported");
     }
-    try {
-      return archive.getInputStream(fh);
-    } catch (RarException e) {
-      throw new IOException(e);
-    }
+    return archive.getInputStream(fh);
   }
 
   @Override


### PR DESCRIPTION
- Apache Tika from 1.7 to 2.4.1. Since tika now has more modules only the needed ones are included
- Apache Commons Compress from 1.9 to 1.21. Aligned with the version used in Apache Tika.
- JUnrar from 0.7 to 7.5.2. Aligned with the version used in Apache Tika.

Added commons-codec since the Tika dependency no longer brings it in transitively.